### PR TITLE
676 step 3: restore cookie checks

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,5 +1,5 @@
 // check if an active campaign is running or OneTrust needs scan the active scripts
-export const COOKIE_CHECK = true;
+export const COOKIE_CHECK = false;
 
 // ONE TRUST COOKIE CONSENT
 export const DATA_DOMAIN_SCRIPT = 'bc931e83-d7f8-4a43-b0d1-402a3ac1f466';


### PR DESCRIPTION
# Step 3

After step 2 (OneTrust scripts scan) this Update restores the overwrite cookie check to let the user choose again

#

Fix [676](https://github.com/hlxsites/vg-macktrucks-com/issues/676)

Test URLs:
- Before: https://main--vg-macktrucks-com-emea--hlxsites.hlx.page/
- After: https://676-restore-cookie-checks--vg-macktrucks-com-emea--hlxsites.hlx.page/
